### PR TITLE
Add Twilio voice gather webhook

### DIFF
--- a/handlers/call_handler.py
+++ b/handlers/call_handler.py
@@ -1,34 +1,35 @@
 """Flask routes for handling Twilio voice calls."""
 
 import os
-import requests
-from flask import Request, Response, current_app, render_template, request
+from flask import Response, request
 from twilio.twiml.voice_response import VoiceResponse
 
-from . import email, gpt_agent, sms, ssh, transcription, tts
+from . import email, gpt_agent, sms, ssh
 
 
 def init_app(app):
     @app.route("/voice", methods=["GET", "POST"])
     def voice() -> Response:
-        """Initial Twilio webhook for incoming calls."""
-        vr = VoiceResponse()
-        vr.say("Welcome to the AI assistant. Please speak after the tone.")
-        vr.record(action="/transcribe", play_beep=True, max_length=60)
-        return Response(str(vr), mimetype="text/xml")
+        """Handle incoming calls and speech input."""
+        speech_text = request.form.get("SpeechResult")
 
-    @app.route("/transcribe", methods=["POST"])
-    def transcribe() -> Response:
-        """Handle recording callback, transcribe and respond."""
-        recording_url = request.form.get("RecordingUrl")
-        audio_content = requests.get(f"{recording_url}.wav").content
-        text = transcription.transcribe_audio(audio_content) or "I did not catch that."
-        reply = gpt_agent.chat_completion([
-            {"role": "system", "content": "You are a helpful voice assistant."},
-            {"role": "user", "content": text},
-        ])
+        if not speech_text:
+            vr = VoiceResponse()
+            gather = vr.gather(
+                input="speech",
+                action="/voice",
+                method="POST",
+            )
+            gather.say("Welcome to the AI assistant. Please speak after the tone.")
+            return Response(str(vr), mimetype="text/xml")
 
-        # Example side actions triggered by keywords in the reply
+        reply = gpt_agent.chat_completion(
+            [
+                {"role": "system", "content": "You are a helpful voice assistant."},
+                {"role": "user", "content": speech_text},
+            ]
+        )
+
         lower = reply.lower()
         if lower.startswith("sms:"):
             sms.send_sms(os.environ.get("TWILIO_TEST_NUMBER", ""), reply[4:].strip())
@@ -46,14 +47,7 @@ def init_app(app):
                 command=reply[4:].strip(),
             )
 
-        # Convert reply to speech or let Twilio speak it
-        speech = tts.synthesize_speech(reply)
-
         vr = VoiceResponse()
-        if speech is None:
-            vr.say(reply)
-        else:
-            # In production, upload speech bytes somewhere and <Play> the URL
-            vr.say(reply)
+        vr.say(reply)
         vr.hangup()
         return Response(str(vr), mimetype="text/xml")

--- a/templates/call_flow.xml
+++ b/templates/call_flow.xml
@@ -1,4 +1,5 @@
 <Response>
-    <Say>Welcome to the AI assistant. Please speak after the tone.</Say>
-    <Record maxLength="60" action="/transcribe" playBeep="true"/>
+    <Gather input="speech" action="/voice" method="POST">
+        <Say>Welcome to the AI assistant. Please speak after the tone.</Say>
+    </Gather>
 </Response>


### PR DESCRIPTION
## Summary
- Handle Twilio voice calls with a /voice webhook that uses `<Gather input="speech">`
- Send gathered speech to OpenAI and speak the reply back to the caller
- Update example TwiML template to reflect gather-based flow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6743347d48327813a3f163dbbb73b