### PR TITLE
Add ElevenLabs TTS playback and transcript logging

### DIFF
--- a/handlers/tts.py
+++ b/handlers/tts.py
@@ -1,9 +1,11 @@
 """Text-to-speech utilities."""
 
 import os
+import uuid
 from typing import Optional
 
 import openai
+import requests
 
 openai.api_key = os.environ.get("OPENAI_API_KEY")
 
@@ -20,3 +22,47 @@ def synthesize_speech(text: str, voice: str = "alloy", model: str = "gpt-4o-mini
     except Exception as exc:  # pragma: no cover - API call
         print(f"TTS failed: {exc}")
         return None
+
+
+def generate_sparkles_voice(text: str) -> str:
+    """Generate speech using ElevenLabs' Sparkles voice.
+
+    The function sends ``text`` to the ElevenLabs text-to-speech API using the
+    Sparkles voice and saves the resulting ``.mp3`` file into the application's
+    ``static`` directory. A public-facing path to the audio file is returned.
+
+    Parameters
+    ----------
+    text:
+        Text to synthesize.
+
+    Returns
+    -------
+    str
+        Relative path to the saved ``.mp3`` file suitable for serving via
+        Flask's static file handler.
+    """
+
+    api_key = os.environ.get("ELEVENLABS_API_KEY")
+    if not api_key:
+        raise RuntimeError("ELEVENLABS_API_KEY not set")
+
+    # TODO: replace with the actual Sparkles voice ID.
+    voice_id = os.environ.get("SPARKLES_VOICE_ID", "<sparkles-voice-id>")
+    url = f"https://api.elevenlabs.io/v1/text-to-speech/{voice_id}"
+    headers = {
+        "xi-api-key": api_key,
+        "Accept": "audio/mpeg",
+        "Content-Type": "application/json",
+    }
+    response = requests.post(url, headers=headers, json={"text": text})
+    response.raise_for_status()
+
+    filename = f"sparkles_{uuid.uuid4().hex}.mp3"
+    static_dir = os.path.join(os.getcwd(), "static")
+    os.makedirs(static_dir, exist_ok=True)
+    file_path = os.path.join(static_dir, filename)
+    with open(file_path, "wb") as f:
+        f.write(response.content)
+
+    return os.path.join("static", filename)

--- a/transcripts/.gitignore
+++ b/transcripts/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/utils/transcript_logger.py
+++ b/utils/transcript_logger.py
@@ -1,0 +1,43 @@
+"""Utility for logging call transcripts."""
+
+import json
+import os
+from datetime import datetime
+from typing import Any, Dict
+
+
+def log_transcript(caller: str, question: str, reply: str) -> str:
+    """Persist a transcript entry to ``/transcripts``.
+
+    Parameters
+    ----------
+    caller:
+        Phone number of the caller.
+    question:
+        User's spoken input.
+    reply:
+        GPT-generated response.
+
+    Returns
+    -------
+    str
+        Path to the JSON transcript file.
+    """
+
+    transcript_dir = os.path.join(os.getcwd(), "transcripts")
+    os.makedirs(transcript_dir, exist_ok=True)
+
+    timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+    data: Dict[str, Any] = {
+        "timestamp": timestamp,
+        "caller": caller,
+        "question": question,
+        "reply": reply,
+    }
+
+    path = os.path.join(transcript_dir, f"{timestamp}.json")
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+    return path
+


### PR DESCRIPTION
## Summary
- integrate ElevenLabs "Sparkles" voice synthesis helper and audio file generation
- switch Twilio voice handler to play generated mp3 and log call transcripts
- record user question, response, and caller number into timestamped JSON files

## Testing
- `python -m py_compile handlers/tts.py handlers/call_handler.py utils/transcript_logger.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c6789a91488327bc2a0ae27a4a5419