### PR TITLE
Add GPT-powered Twilio voice endpoint

### DIFF
--- a/utils/transcript_logger.py
+++ b/utils/transcript_logger.py
@@ -35,7 +35,13 @@ def log_transcript(caller: str, question: str, reply: str) -> str:
         "reply": reply,
     }
 
-    path = os.path.join(transcript_dir, f"{timestamp}.json")
+    safe_caller = (
+        caller.replace("+", "")
+        .replace(" ", "")
+        .replace(":", "")
+        .replace("/", "")
+    )
+    path = os.path.join(transcript_dir, f"{timestamp}_{safe_caller}.json")
     with open(path, "w", encoding="utf-8") as f:
         json.dump(data, f, ensure_ascii=False, indent=2)
 


### PR DESCRIPTION
## Summary
- handle Twilio voice webhooks at `/voice` using speech gather
- call GPT for responses and speak results back with <Say>
- log call transcripts with timestamp and caller number

## Testing
- `python -m py_compile handlers/call_handler.py utils/transcript_logger.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c67b9e25a0832796616a72fc5f6679