### PR TITLE
Add GPT response helper and transcript logger

### DIFF
--- a/handlers/gpt_agent.py
+++ b/handlers/gpt_agent.py
@@ -5,15 +5,17 @@ import logging
 from typing import List
 
 import openai
+from openai.error import OpenAIError
 
-openai.api_key = os.environ.get("OPENAI_API_KEY")
 logger = logging.getLogger(__name__)
 
 
 def chat_completion(messages: List[dict], model: str = "gpt-4o-mini") -> str:
     """Send messages to OpenAI ChatCompletion."""
-    if not openai.api_key:
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
         raise RuntimeError("OPENAI_API_KEY not set")
+    openai.api_key = api_key
     resp = openai.ChatCompletion.create(model=model, messages=messages)
     return resp["choices"][0]["message"]["content"]
 
@@ -32,18 +34,20 @@ def get_gpt_response(prompt: str) -> str:
         The assistant's textual reply.
     """
 
-    if not openai.api_key:
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
         raise RuntimeError("OPENAI_API_KEY not set")
+    openai.api_key = api_key
 
     try:
         response = openai.ChatCompletion.create(
             model="gpt-3.5-turbo",
             messages=[{"role": "user", "content": prompt}],
         )
-    except openai.error.OpenAIError as exc:
+    except OpenAIError as exc:
         logger.error("OpenAI API error: %s", exc)
         raise
-    except Exception as exc:  # pragma: no cover - unexpected errors
+    except Exception:  # pragma: no cover - unexpected errors
         logger.exception("Unexpected error when calling OpenAI API")
         raise
 

--- a/utils/transcript_logger.py
+++ b/utils/transcript_logger.py
@@ -1,4 +1,6 @@
-"""Utility for logging call transcripts."""
+"""Utility for persisting call transcripts to JSON files."""
+
+from __future__ import annotations
 
 import json
 import os
@@ -6,17 +8,21 @@ from datetime import datetime
 from typing import Any, Dict
 
 
-def log_transcript(caller: str, question: str, reply: str) -> str:
-    """Persist a transcript entry to ``/transcripts``.
+def log_transcript(call_sid: str, from_number: str, to_number: str, user_text: str, gpt_reply: str) -> str:
+    """Persist a transcript entry to ``transcripts/``.
 
     Parameters
     ----------
-    caller:
-        Phone number of the caller.
-    question:
-        User's spoken input.
-    reply:
-        GPT-generated response.
+    call_sid:
+        Identifier for the call from Twilio.
+    from_number:
+        Caller phone number.
+    to_number:
+        Callee phone number.
+    user_text:
+        User's transcribed speech.
+    gpt_reply:
+        Response from GPT model.
 
     Returns
     -------
@@ -27,23 +33,23 @@ def log_transcript(caller: str, question: str, reply: str) -> str:
     transcript_dir = os.path.join(os.getcwd(), "transcripts")
     os.makedirs(transcript_dir, exist_ok=True)
 
-    timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+    now = datetime.utcnow()
+    timestamp = now.isoformat()
+    file_ts = now.strftime("%Y%m%d_%H%M%S")
     data: Dict[str, Any] = {
         "timestamp": timestamp,
-        "caller": caller,
-        "question": question,
-        "reply": reply,
+        "call_sid": call_sid,
+        "from": from_number,
+        "to": to_number,
+        "user_text": user_text,
+        "gpt_reply": gpt_reply,
     }
 
-    safe_caller = (
-        caller.replace("+", "")
-        .replace(" ", "")
-        .replace(":", "")
-        .replace("/", "")
-    )
-    path = os.path.join(transcript_dir, f"{timestamp}_{safe_caller}.json")
+    safe_sid = "".join(ch for ch in call_sid if ch.isalnum())
+    filename = f"call_{file_ts}_{safe_sid}.json"
+    path = os.path.join(transcript_dir, filename)
+
     with open(path, "w", encoding="utf-8") as f:
         json.dump(data, f, ensure_ascii=False, indent=2)
 
     return path
-


### PR DESCRIPTION
## Summary
- Use `OPENAI_API_KEY` from the environment when interacting with OpenAI in GPT helper
- Add transcript logger utility that writes detailed call transcripts to JSON files

## Testing
- `python -m py_compile handlers/gpt_agent.py utils/transcript_logger.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6888787248327b8077bbacb1e26eb