### PR TITLE
Fix incorrect OpenAIError import path

### DIFF
--- a/handlers/gpt_agent.py
+++ b/handlers/gpt_agent.py
@@ -5,7 +5,7 @@ import logging
 from typing import List
 
 import openai
-from openai.error import OpenAIError
+from openai import OpenAIError
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- fix incorrect OpenAIError import path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c6ea5c44648327822d696d6b2af480